### PR TITLE
Back the probes with a bit ring instead of an array

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,26 @@
+var Benchmark = require('benchmark');
+var BitRing = require('./bit-ring');
+var Prober = require('./index');
+
+var suite = new Benchmark.Suite();
+var prober = new Prober();
+var healthy = function(callback) {
+    callback();
+};
+var error = new Error('unhealthy');
+var unhealthy = function(callback) {
+    callback(error);
+};
+var bitRing = new BitRing(10);
+
+suite.add('probe healthy', function() {
+    prober.probe(healthy);
+}).add('probe unhealthy', function() {
+    prober.probe(unhealthy);
+}).add('bitRing', function() {
+    bitRing.count();
+    bitRing.push(true);
+    bitRing.count();
+}).on('cycle', function(event) {
+    console.log(String(event.target));
+}).run();

--- a/bit-ring.js
+++ b/bit-ring.js
@@ -1,9 +1,6 @@
-var assert = require('assert');
-
 function BitRing(capacity) {
-    assert.ok(capacity < 32, 'Capacity must be less than 32');
     this.capacity = capacity;
-    this.bits = 0;
+    this.bits = new Uint8ClampedArray(capacity);
     this.pos = 0;
     this.length = 0;
     this._count = 0;
@@ -12,8 +9,8 @@ function BitRing(capacity) {
 // Update the count and set or clear the next bit in the ring
 BitRing.prototype.push = function(bool) {
     var num = bool === true ? 1 : 0;
-    this._count += num - ((this.bits >>> this.pos) & 1);
-    this.bits ^= (-num ^ this.bits) & (1 << this.pos);
+    this._count += num - this.bits[this.pos];
+    this.bits[this.pos] = num;
     this.pos = (this.pos + 1) % this.capacity;
     if (this.length < this.capacity) {
         this.length++;

--- a/bit-ring.js
+++ b/bit-ring.js
@@ -1,0 +1,29 @@
+var assert = require('assert');
+
+function BitRing(capacity) {
+    assert.ok(capacity < 32, 'Capacity must be less than 32');
+    this.capacity = capacity;
+    this.bits = 0;
+    this.head = 0;
+    this.length = 0;
+}
+
+// Set or clear the next bit in the ring and advance the head
+BitRing.prototype.push = function(bool) {
+    this.bits ^= (-bool ^ this.bits) & (1 << this.head);
+    this.head = (this.head + 1) % this.capacity;
+    if (this.length < this.capacity) {
+        this.length++;
+    }
+};
+
+// Count the number of bits set
+// http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+BitRing.prototype.count = function() {
+    var v = this.bits;
+    v = v - ((v >>> 1) & 0x55555555);
+    v = (v & 0x33333333) + ((v >>> 2) & 0x33333333);
+    return ((v + (v >>> 4) & 0xF0F0F0F) * 0x1010101) >>> 24;
+};
+
+module.exports = BitRing;

--- a/bit-ring.js
+++ b/bit-ring.js
@@ -4,26 +4,25 @@ function BitRing(capacity) {
     assert.ok(capacity < 32, 'Capacity must be less than 32');
     this.capacity = capacity;
     this.bits = 0;
-    this.head = 0;
+    this.pos = 0;
     this.length = 0;
+    this._count = 0;
 }
 
-// Set or clear the next bit in the ring and advance the head
+// Update the count and set or clear the next bit in the ring
 BitRing.prototype.push = function(bool) {
-    this.bits ^= (-bool ^ this.bits) & (1 << this.head);
-    this.head = (this.head + 1) % this.capacity;
+    var num = bool === true ? 1 : 0;
+    this._count += num - ((this.bits >>> this.pos) & 1);
+    this.bits ^= (-num ^ this.bits) & (1 << this.pos);
+    this.pos = (this.pos + 1) % this.capacity;
     if (this.length < this.capacity) {
         this.length++;
     }
 };
 
-// Count the number of bits set
-// http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+// Return the number of bits set
 BitRing.prototype.count = function() {
-    var v = this.bits;
-    v = v - ((v >>> 1) & 0x55555555);
-    v = (v & 0x33333333) + ((v >>> 2) & 0x33333333);
-    return ((v + (v >>> 4) & 0xF0F0F0F) * 0x1010101) >>> 24;
+    return this._count;
 };
 
 module.exports = BitRing;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~1.15.1",
+    "benchmark": "^1.0.0",
+    "istanbul": "~0.1.46",
     "lodash.times": "~2.4.1",
-    "time-mock": "~0.1.2",
-    "istanbul": "~0.1.46"
+    "mocha": "~1.15.1",
+    "time-mock": "~0.1.2"
   },
   "scripts": {
     "test": "npm run jshint && mocha --reporter tap ./test 2>&1 | tee ./test/test.js.tap",

--- a/test/bit-ring.js
+++ b/test/bit-ring.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+var BitRing = require('../bit-ring');
+var test = global.it;
+
+test('empty bit ring', function(end) {
+    var bitRing = new BitRing(3);
+    assert.equal(bitRing.length, 0);
+    assert.equal(bitRing.count(), 0);
+    end();
+});
+
+test('set bit', function(end) {
+    var bitRing = new BitRing(3);
+    bitRing.push(true);
+    assert.equal(bitRing.length, 1);
+    assert.equal(bitRing.count(), 1);
+    end();
+});
+
+test('clear bit', function(end) {
+    var bitRing = new BitRing(3);
+    bitRing.push(true);
+    bitRing.push(true);
+    assert.equal(bitRing.length, 2);
+    assert.equal(bitRing.count(), 2);
+    bitRing.push(false);
+    assert.equal(bitRing.length, 3);
+    assert.equal(bitRing.count(), 2);
+    bitRing.push(false);
+    assert.equal(bitRing.length, 3);
+    assert.equal(bitRing.count(), 1);
+    end();
+});


### PR DESCRIPTION
This speeds up the code impacted by this change by about 7000x

```
before x 1,613 ops/sec ±67.62% (6 runs sampled)
after x 11,917,565 ops/sec ±1.38% (89 runs sampled)
```